### PR TITLE
Integrate Konnection library for network status monitoring

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/smartroots/MainApplication.kt
+++ b/composeApp/src/androidMain/kotlin/org/smartroots/MainApplication.kt
@@ -1,6 +1,7 @@
 package org.smartroots
 
 import android.app.Application
+import dev.tmapps.konnection.Konnection
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.component.KoinComponent
@@ -10,7 +11,7 @@ class MainApplication : Application(), KoinComponent {
 
     override fun onCreate() {
         super.onCreate()
-
+        val konnection = Konnection.createInstance(context = this)
         initKoin() {
             androidLogger()
             androidContext(this@MainApplication)

--- a/composeApp/src/androidMain/kotlin/org/smartroots/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/smartroots/Platform.android.kt
@@ -3,11 +3,13 @@ package org.smartroots
 
 import android.os.Build
 import androidx.room.RoomDatabase
+import dev.tmapps.konnection.Konnection
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 import org.smartroots.data.database.AppDatabase
 
@@ -21,7 +23,7 @@ actual fun platformModule() = module {
     single<RoomDatabase.Builder<AppDatabase>> {
         getDatabaseBuilder(get())
     }
-
+    single { Konnection.createInstance(androidContext()) }
 }
 
 

--- a/composeApp/src/commonMain/kotlin/org/smartroots/Module.kt
+++ b/composeApp/src/commonMain/kotlin/org/smartroots/Module.kt
@@ -1,5 +1,6 @@
 package org.smartroots
 
+import dev.tmapps.konnection.Konnection
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
@@ -66,7 +67,8 @@ val sensorRepositoryModule = module {
     }
 }
 val networkConfigModule = module {
-    factory<NetworkService> { NetworkConfig() }
+    factory<NetworkService> { NetworkConfig(get()) }
+    single { Konnection.createInstance() }
 }
 
 // network configREpo

--- a/composeApp/src/commonMain/kotlin/org/smartroots/data/model/NetworkConfigState.kt
+++ b/composeApp/src/commonMain/kotlin/org/smartroots/data/model/NetworkConfigState.kt
@@ -8,5 +8,5 @@ import dev.tmapps.konnection.NetworkConnection
  */
 data class NetworkConfigState(
     val currentConnectionStatus: NetworkConnection? = NetworkConnection.UNKNOWN_CONNECTION_TYPE,
-    val konnection: Konnection = Konnection.instance
+    val konnection: Konnection?
 )

--- a/composeApp/src/commonMain/kotlin/org/smartroots/data/service/NetworkConfig.kt
+++ b/composeApp/src/commonMain/kotlin/org/smartroots/data/service/NetworkConfig.kt
@@ -1,18 +1,20 @@
 package org.smartroots.data.service
 
+import dev.tmapps.konnection.Konnection
 import dev.tmapps.konnection.NetworkConnection
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.compose.getKoin
 import org.smartroots.data.model.NetworkConfigState
 
 /**
  *  @author Shravan Ramjathan
  */
-class NetworkConfig() : NetworkService {
+class NetworkConfig(val konnection: Konnection) : NetworkService {
     private val _currentConnectionStatus =
-        MutableStateFlow<NetworkConfigState>(NetworkConfigState())
+        MutableStateFlow<NetworkConfigState>(NetworkConfigState(konnection = konnection))
     val currentConnectionStatus: StateFlow<NetworkConfigState> =
         _currentConnectionStatus.asStateFlow()
 
@@ -20,13 +22,13 @@ class NetworkConfig() : NetworkService {
     override fun checkNetworkConnectionStatus(): NetworkConnection? {
         val currentInstance = _currentConnectionStatus.value.konnection
         _currentConnectionStatus.update { currentState ->
-            currentState.copy(currentConnectionStatus = currentInstance.getCurrentNetworkConnection())
+            currentState.copy(currentConnectionStatus = currentInstance?.getCurrentNetworkConnection())
         }
         return currentConnectionStatus.value.currentConnectionStatus
     }
 
     override suspend fun currentIPV4Address(): String? {
-        val currentNetworkInfo = _currentConnectionStatus.value.konnection.getInfo()
+        val currentNetworkInfo = _currentConnectionStatus.value.konnection?.getInfo()
         val currentIPv4Address = currentNetworkInfo?.ipv4
         return if (currentIPv4Address != null) currentIPv4Address else null
     }


### PR DESCRIPTION
This commit integrates the Konnection library to provide network connection status information.

Key changes:
- Added `Konnection.createInstance()` as a singleton in both common and Android-specific Koin modules.
- `NetworkConfig` now takes a `Konnection` instance as a constructor parameter.
- `NetworkConfigState` now holds a nullable `Konnection` instance.
- Initialized `Konnection` in `MainApplication` for Android.
- Updated `NetworkConfig` to use the injected `Konnection` instance and handle potential nullability.