### PR TITLE
Include platform module in Koin tests

### DIFF
--- a/composeApp/src/commonTest/kotlin/org/smartroots/test/KoinGraphSmokeTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/smartroots/test/KoinGraphSmokeTest.kt
@@ -1,20 +1,36 @@
 package org.smartroots.test
 
-import kotlin.test.*
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import org.koin.test.KoinTest
 import org.koin.test.get
-import org.smartroots.*
+import org.smartroots.GetSensorReadingsUseCaseModule
+import org.smartroots.NetworkConnectionUseCaseModule
+import org.smartroots.ktorClientModule
+import org.smartroots.networkConfigModule
+import org.smartroots.networkRepositoryModule
+import org.smartroots.platformModule
+import org.smartroots.sensorRepositoryModule
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 /**
  * Validates DI wiring for services/repos/use cases without Room/Android.
  */
 class KoinGraphSmokeTest : KoinTest {
 
-    @BeforeTest fun before() { stopKoin() }
-    @AfterTest  fun after()  { stopKoin() }
+    @BeforeTest
+    fun before() {
+        stopKoin()
+    }
+
+    @AfterTest
+    fun after() {
+        stopKoin()
+    }
 
     @Test
     fun
@@ -37,7 +53,7 @@ class KoinGraphSmokeTest : KoinTest {
                 GetSensorReadingsUseCaseModule,
                 // homeViewModelModule, // enable when you want to resolve the VM too
                 ktorClientModule,
-
+                platformModule(),
                 // Test overrides last
                 testOverrides
             )

--- a/composeApp/src/commonTest/kotlin/org/smartroots/test/NetworkConfigRepositoryWiringTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/smartroots/test/NetworkConfigRepositoryWiringTest.kt
@@ -22,7 +22,8 @@ class NetworkConfigRepositoryWiringTest : KoinTest {
             modules(
                 networkConfigModule,
                 networkRepositoryModule,
-                testOverrides
+                testOverrides,
+                platformModule()
             )
         }
 

--- a/composeApp/src/desktopMain/kotlin/org/smartroots/Platform.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/org/smartroots/Platform.jvm.kt
@@ -19,7 +19,9 @@ actual fun getPlatform(): Platform = JVMPlatform()
 actual fun platformModule() = module {
     single<RoomDatabase.Builder<AppDatabase>> {
         getDatabaseBuilder()
+
     }
+    single{createHttpClient()}
 }
 
 actual fun createHttpClient(): HttpClient {


### PR DESCRIPTION
This commit updates the Koin graph smoke test and network config repository wiring test to include the `platformModule`.

Additionally, the JVM platform module now provides an `HttpClient` instance.